### PR TITLE
fix: md_spliter string expected

### DIFF
--- a/lib/md_spliter.js
+++ b/lib/md_spliter.js
@@ -9,7 +9,7 @@ class MarkdownSpliter {
     }
 
     split(md) {
-        const html = marked.parse(md);
+        const html = marked.parse(md.toString());
         const htmldoc = xml.parse(html, "text/html");
         
         if (this.opts.ignore_tags)


### PR DESCRIPTION
error
```bash
 return throwError(new Error('marked(): input parameter is of type ' + Object.prototype.toString.call(src) + ', string expected'));
                        ^
Error: marked(): input parameter is of type [object Uint8Array], string expected
```